### PR TITLE
login_Ouath 네이버&카카오

### DIFF
--- a/apps/web-login/CallBack.html
+++ b/apps/web-login/CallBack.html
@@ -1,0 +1,53 @@
+<!-- 네이버 callback 전용 html 파일 -->
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <script
+      type="text/javascript"
+      src="https://static.nid.naver.com/js/naverLogin_implicit-1.0.3.js"
+      charset="utf-8"
+    ></script>
+    <script
+      type="text/javascript"
+      src="http://code.jquery.com/jquery-1.11.3.min.js"
+    ></script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      const ID = "Hw7RwBFOB7UjSufSEEjy";
+      var naver_id_login = new naver_id_login(
+        ID,
+        "http://192.168.0.12:8887/Login.html#"
+      );
+      // 접근 토큰 값 출력
+      alert(naver_id_login.oauthParams.access_token);
+      // 네이버 사용자 프로필 조회
+      naver_id_login.get_naver_userprofile("naverSignInCallback()");
+      // 네이버 사용자 프로필 조회 이후 프로필 정보를 처리할 callback function
+      function naverSignInCallback() {
+        alert(naver_id_login.getProfileData("email"));
+        alert(naver_id_login.getProfileData("nickname"));
+        alert(naver_id_login.getProfileData("age"));
+        alert("로그인 성공");
+      }
+    </script>
+
+    <div>
+      <button onclick="logOut()" , class="btn">Log out</button>
+      <script>
+        const id = "Hw7RwBFOB7UjSufSEEjy";
+        const secret = "MaLARH3T4B";
+
+        function logOut() {
+          // window.open(
+          //   `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=Hw7RwBFOB7UjSufSEEjy&client_secret=MaLARH3T4B&access_token=c8ceMEJisO4Se7uGCEYKK1p52L93bHXLnaoETis9YzjfnorlQwEisqemfpKHUq2gY&service_provider=NAVER`
+          // );
+          window.open(`https://nid.naver.com/nidlogin.logout`);
+          // window.close();
+        }
+      </script>
+    </div>
+  </body>
+</html>
+
+<!-- //https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=jyvqXeaVOVmV&client_secret=527300A0_COq1_XV33cf&access_token=c8ceMEJisO4Se7uGCEYKK1p52L93bHXLnaoETis9YzjfnorlQwEisqemfpKHUq2gY&service_provider=NAVER -->

--- a/apps/web-login/Login.html
+++ b/apps/web-login/Login.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Login Page</title>
+    <link rel="stylesheet" href="loginStyle.css" />
+    <script
+      type="text/javascript"
+      src="https://static.nid.naver.com/js/naverLogin_implicit-1.0.3.js"
+      charset="utf-8"
+    ></script>
+    <script src="https://t1.kakaocdn.net/kakao_js_sdk/v1/kakao.js">
+      // kakao
+    </script>
+    <script
+      type="text/javascript"
+      src="http://code.jquery.com/jquery-1.11.3.min.js"
+    ></script>
+  </head>
+  <body>
+    <div class="login-box">
+      <h2>Login</h2>
+      <form>
+        <div class="user-box">
+          <input type="text" name="" required="" />
+          <label>Username</label>
+        </div>
+        <div class="user-box">
+          <input type="password" name="" required="" />
+          <label>Password</label>
+        </div>
+        <a href="#"> Submit </a>
+      </form>
+      <div class="oauth-login">
+        <ul>
+          <li id="kakao-login-btn" onclick="kakaoLogin();">
+            <img
+              src="https://k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
+              width="222"
+              alt="카카오 로그인 버튼"
+            />
+
+            <!-- <a href="javascript:void(0)">
+              <span>카카오 로그인</span>
+            </a> -->
+          </li>
+          <li onclick="kakaoLogout();">
+            <a href="javascript:void(0)">
+              <!-- <span>카카오 로그아웃</span> -->
+              <button style="background-color: white">카카오 로그아웃</button>
+            </a>
+          </li>
+        </ul>
+        <!-- 카카오 스크립트 -->
+        <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+        <script></script>
+
+        <!-- <a id="kakao-login-btn" href="javascript:kakaoLogin();">
+        <img
+          src="https://k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
+          width="222"
+          alt="카카오 로그인 버튼"
+        />
+      </a> -->
+        <div id="naver_id_login"></div>
+
+        <script src="Login.js"></script>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/web-login/Login.js
+++ b/apps/web-login/Login.js
@@ -1,0 +1,79 @@
+// naver ouath part
+const WEB_IP = "http://192.168.0.12:8887/Login.html#";
+const CALLBACK_IP = "http://192.168.0.12:8887/CallBack.html";
+const CLIENT_ID = "Hw7RwBFOB7UjSufSEEjy";
+
+var naver_id_login = new naver_id_login(CLIENT_ID, CALLBACK_IP);
+var state = naver_id_login.getUniqState();
+naver_id_login.setButton("white", 2, 40);
+naver_id_login.setDomain(WEB_IP);
+naver_id_login.setState(state);
+naver_id_login.setPopup();
+naver_id_login.init_naver_id_login();
+
+// kakao ouath part
+Kakao.init("13cee8f0d511dff11f766fe1d031b0a1"); //발급받은 키 중 javascript키를 사용해준다.
+console.log(Kakao.isInitialized()); // sdk초기화여부판단
+//카카오로그인
+function kakaoLogin() {
+  Kakao.Auth.login({
+    success: function (response) {
+      Kakao.API.request({
+        url: "/v2/user/me",
+        success: function (response) {
+          console.log(response);
+          alert("success login");
+          openNew(); // 세로운 창을 띄우고 싶은데 왜 안되는 걸까요? 알려 주세요
+        },
+        fail: function (error) {
+          console.log(error);
+        },
+      });
+    },
+    fail: function (error) {
+      console.log(error);
+    },
+  });
+}
+function openNew() {
+  windowOpen(
+    // https://developers.kakao.com/sdk/js/kakao.js 에 있는 함수를 사용하려고 하는데 오류가 나와요 ㅠㅠ
+    "https://t1.kakaocdn.net/kakao_js_sdk/v1/kakao.js",
+    "_blank",
+    "width=400,height=400"
+  );
+}
+
+//카카오로그아웃
+function kakaoLogout() {
+  if (Kakao.Auth.getAccessToken()) {
+    Kakao.API.request({
+      url: "/v1/user/unlink",
+      success: function (response) {
+        console.log(response);
+      },
+      fail: function (error) {
+        console.log(error);
+      },
+    });
+    Kakao.Auth.setAccessToken(undefined);
+  }
+}
+
+// 수정중인 부분 로그인 기능만 유지한 채로
+// function kakaoLogin() {
+//   window.Kakao.Auth.login({
+//     scope: "profile_nickname, account_email, gender",
+//     success: function (authObj) {
+//       alert("로그인 성공");
+//       console.log(authObj);
+//       // window.Kakao.API.request({
+//       //   url: "/v2/user/me",
+//       //   success: res => {
+//       //     const kakao_account = res.kako_account;
+//       //     console.log(kakao_account);
+//       //   },
+//       // });
+//     },
+//   });
+// }

--- a/apps/web-login/loginStyle.css
+++ b/apps/web-login/loginStyle.css
@@ -1,0 +1,97 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+}
+
+body {
+  background-color: #f2f2f2;
+}
+
+.login-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400px;
+  padding: 40px;
+  background-color: #fff;
+  border-radius: 10px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+}
+
+.login-box h2 {
+  margin-bottom: 30px;
+  color: #333;
+  text-align: center;
+}
+
+.login-box .user-box {
+  position: relative;
+}
+
+.login-box .user-box input {
+  width: 100%;
+  padding: 10px 0;
+  font-size: 16px;
+  color: #333;
+  margin-bottom: 30px;
+  border: none;
+  border-bottom: 2px solid #ccc;
+  outline: none;
+  background: transparent;
+}
+
+.login-box .user-box label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 16px;
+  color: #999;
+  pointer-events: none;
+  transition: 0.5s;
+}
+
+.login-box .user-box input:focus ~ label,
+.login-box .user-box input:valid ~ label {
+  top: -20px;
+  left: 0;
+  color: #333;
+  font-size: 12px;
+}
+
+.login-box a {
+  display: inline-block;
+  background-color: #333;
+  color: #fff;
+  text-transform: uppercase;
+  text-decoration: none;
+  font-size: 16px;
+  padding: 10px 20px;
+  margin-top: 40px;
+  border-radius: 25px;
+  position: relative;
+  overflow: hidden;
+  transition: 0.5s;
+}
+
+.login-box a:hover {
+  background-color: #fff;
+  color: #333;
+}
+
+.login-box a span {
+  position: absolute;
+  display: block;
+  background-color: #fff;
+}
+
+.login-box a span:nth-child(1) {
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 2px;
+  background-color: #333;
+  animation: animate1 1s linear infinite;
+}


### PR DESCRIPTION
### 관련 이슈
https://github.com/earning-rightly/level-up-test/issues/2

### 내용
네이버 카카오 Ouath 로그인을 만들었습니다. 
네이버는 login.html과 callback.html 2개에 나눠서 만들었습니다. (데모가 있어서 가져와서 사용했습니다.) 네이버 로그아웃은 
카카오는 loginhtml안에서 구현했습니다. (마찬가지로 데모가 있어서 가져왔습니다)
로그아웃 기능까지 만들기는 했는데 네이버 로그아웃은 callback.htm 에 "https://nid.naver.com/nidlogin.logout"링크를 통해서
구현했는데 토큰을 없에서 하는 것이 아니라서 그런지 chrome 전체에서  네이버가 로그아웃됩니다. 
카카오는 현재 페이지에서만 로그아웃이 되는데 네이버로그인 처럼 새로운 창을 띄우고 싶은데 그것이 안되서 어떻게 가야 할지
여쭤보고 싶습니다.